### PR TITLE
Support for `abi_stable`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,11 @@ exclude = ["/link_tests"]
 rust-version = "1.49" # 1.48 doesn't support `ManuallyDrop` in union.
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[dependencies]
+abi_stable = { version = "0.10", default-features = false, optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.4.0", features = ["macros", "rt-multi-thread", "sync", "time"] }
+
+[features]
+sabi = ["abi_stable"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,3 @@ abi_stable = { version = "0.10", default-features = false, optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.4.0", features = ["macros", "rt-multi-thread", "sync", "time"] }
-
-[features]
-sabi = ["abi_stable"]


### PR DESCRIPTION
This is my attempt at adding support for `abi_stable`, as explained in #9.

The only changes I had to make were:

* Add `cfg_attr` with `derive(StableAbi)` in case the `sabi` feature is enabled
* Introduce `FfiWakerBase`, which is fully FFI-safe for *only* having FFI-safe fields (only the vtable).

TODO:

* [ ] Document new feature
* [ ] Make sure the tests still work
* [ ] Is https://github.com/oxalica/async-ffi/pull/10/commits/f066b51241ebdf6e95dbf59cf13ec187476dc3a3 worth it? IMO it makes more sense, and it might also be useful because we'd be able to hold more fields in the waker base, other than the vtable. But not sure if it's necessary at all. AFAIK casting between the types in both cases is safe anyway.