### PR TITLE
Cbindgen support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ If you want to use this crate with [`abi-stable`] interfaces. You can enable the
 
 [`abi-stable`]: https://github.com/rodrimati1992/abi_stable_crates/
 
+## [`cbindgen`] support
+
+This crate includes support for [`cbindgen`]. You can generate the C/C++ bindings with:
+
+```
+$ cbindgen --config cbindgen.toml --output async_ffi.h
+```
+
+[`cbindgen`]: https://github.com/eqrion/cbindgen
+
 #### License
 
 MIT Licensed.

--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -1,0 +1,11 @@
+language = "C"
+cpp_compat = true
+
+[export]
+include = [
+    "FfiWakerVTable",
+    "FfiWakerBase",
+    "FfiContext",
+    "FfiPoll",
+    "FfiFuture"
+]


### PR DESCRIPTION
Here's proof that, as #9 explains, after adding `FfiWakerBase`, generating bindings with `cbindgen` works perfectly. IMO this is preferred to defining your own types in the `.c` file. You can just run `cbindgen` and copy that header to your project, with a guarantee that the layout will be the exact same.

TODO:

- [ ] The problem here is that `cbindgen` doesn't make much sense for generics. So `FfiFuture` and `FfiPoll` are included in the config, but they won't be generated. Not sure how to approach that (I think it's impossible, and we'd have to tell the user to define their own version, like `FfiFutureU32` in the examples).
- [ ] Document in `README.md` perhaps

Note that this should point to my `sabi` branch, and not to `master`, but otherwise the PR would be created on my fork instead of here. Once `sabi` is merged this will make more sense.