### PR TITLE
remove misleading and useless #[repr(C)]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,13 +305,11 @@ impl<'a> ContextExt for Context<'a> {
 struct FfiWakerBase {
     vtable: *const FfiWakerVTable,
 }
-#[repr(C)]
 struct FfiWaker {
     base: FfiWakerBase,
     waker: WakerUnion,
 }
 
-#[repr(C)]
 union WakerUnion {
     reference: *const Waker,
     owned: ManuallyDrop<Waker>,


### PR DESCRIPTION
Just a little PR, removes `#[repr(C)]` from `FfiWaker` and `WakerUnion`, since there is no reason to have it on them. They are not FFI-safe, since they have `ManuallyDrop<Waker>` which is not stable, and doesn't have a defined size.