### PR TITLE
stabby

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,7 @@ jobs:
           MIRIFLAGS: -Zmiri-strict-provenance
 
   minimal:
-    name: MSRV 1.56
+    name: MSRV 1.60
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -85,7 +85,7 @@ jobs:
       - name: Install Rust
         run: |
           rustup update --no-self-update nightly
-          rustup default 1.56
+          rustup default 1.60
 
       - run: cargo +nightly generate-lockfile -Z minimal-versions
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,9 @@ exclude = ["/link_tests", "/.github"]
 rust-version = "1.56" # syn 2 requires edition 2021
 
 [dependencies]
-abi_stable = { version = "0.11", default-features = false, optional = true }
+abi_stable = { version = "0.11.3", default-features = false, optional = true }
 macros = { version = "0.5", package = "async-ffi-macros", path = "./macros", optional = true }
+stabby = { version = "36.1.1", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,12 @@ license = "MIT"
 repository = "https://github.com/oxalica/async-ffi"
 readme = "README.md"
 exclude = ["/link_tests", "/.github"]
-rust-version = "1.56" # syn 2 requires edition 2021
+rust-version = "1.60" # stabby needs 1.60
 
 [dependencies]
 abi_stable = { version = "0.11.3", default-features = false, optional = true }
 macros = { version = "0.5", package = "async-ffi-macros", path = "./macros", optional = true }
-stabby = { version = "36.1.1", optional = true }
+stabby = { version = "72.1.1", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -378,6 +378,7 @@ mod private {
     #[repr(C)]
     #[cfg_attr(feature = "abi_stable", derive(abi_stable::StableAbi))]
     #[cfg_attr(feature = "stabby", stabby::stabby)]
+    // why `T` here: break the type checking cycle
     pub struct FfiWakerVTable<T = FfiWakerBase> {
         pub(super) clone: unsafe extern "C" fn(*const T) -> *const T,
         pub(super) wake: unsafe extern "C" fn(*const T),


### PR DESCRIPTION
`abi_stable` seems to have been abandoned

~~I don't yet know what the implications of this are in terms of how `stabby` lays stuff out in memory (especially `enum`s)~~ (nvm, checked, shouldn't affect since we're doing `repr(C)`), still need to at least run tests lol

(I had this change made something like 6 months ago but then forgot to push it anywhere, tried to fix `abi_stable` first instead)

had to rearrange code somewhat, unfortunately, since `stabby` wants stuff to be `pub`
